### PR TITLE
Rename all optmotiongen to optmotiongen_core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,7 @@ find_package(catkin REQUIRED COMPONENTS
   visualization_msgs
   sensor_msgs
   grid_map_ros
-  optmotiongen
-  )
+  optmotiongen_core)
 
 # Boost
 # Use Boost.Geometry which is header-only library
@@ -71,7 +70,7 @@ catkin_package(
   visualization_msgs
   sensor_msgs
   grid_map_ros
-  optmotiongen
+  optmotiongen_core
   DEPENDS EIGEN3
   INCLUDE_DIRS include
   LIBRARIES OmgCore

--- a/include/differentiable_rmap/RmapPlanning.h
+++ b/include/differentiable_rmap/RmapPlanning.h
@@ -11,8 +11,11 @@
 #include <grid_map_ros/grid_map_ros.hpp>
 
 #include <libsvm/svm.h>
-
-#include <optmotiongen/Utils/QpUtils.h>
+#ifdef OPTMOTIONGEN_V2
+  #include <optmotiongen_core/Utils/QpUtils.h>
+#else
+  #include <optmotiongen/Utils/QpUtils.h>
+#endif
 
 #include <differentiable_rmap/RosUtils.h>
 #include <differentiable_rmap/SamplingUtils.h>

--- a/include/differentiable_rmap/RmapPlanningPlacement.h
+++ b/include/differentiable_rmap/RmapPlanningPlacement.h
@@ -4,9 +4,15 @@
 
 #include <std_srvs/Empty.h>
 
-#include <optmotiongen/Problem/IterativeQpProblem.h>
-#include <optmotiongen/Task/BodyTask.h>
-#include <optmotiongen/Utils/RobotUtils.h>
+#ifdef OPTMOTIONGEN_V2
+  #include <optmotiongen_core/Problem/IterativeQpProblem.h>
+  #include <optmotiongen_core/Task/BodyTask.h>
+  #include <optmotiongen_core/Utils/RobotUtils.h>
+#else
+  #include <optmotiongen/Problem/IterativeQpProblem.h>
+  #include <optmotiongen/Task/BodyTask.h>
+  #include <optmotiongen/Utils/RobotUtils.h>
+#endif
 
 #include <differentiable_rmap/RmapPlanning.h>
 

--- a/include/differentiable_rmap/RmapSampling.h
+++ b/include/differentiable_rmap/RmapSampling.h
@@ -7,8 +7,13 @@
 #include <ros/ros.h>
 #include <sensor_msgs/PointCloud.h>
 
-#include <optmotiongen/Task/CollisionTask.h>
-#include <optmotiongen/Utils/RobotUtils.h>
+#ifdef OPTMOTIONGEN_V2
+  #include <optmotiongen_core/Task/CollisionTask.h>
+  #include <optmotiongen_core/Utils/RobotUtils.h>
+#else
+  #include <optmotiongen/Task/CollisionTask.h>
+  #include <optmotiongen/Utils/RobotUtils.h>
+#endif
 
 #include <differentiable_rmap/SamplingUtils.h>
 

--- a/include/differentiable_rmap/RmapSamplingIK.h
+++ b/include/differentiable_rmap/RmapSamplingIK.h
@@ -2,8 +2,13 @@
 
 #pragma once
 
-#include <optmotiongen/Problem/IterativeQpProblem.h>
-#include <optmotiongen/Task/BodyTask.h>
+#ifdef OPTMOTIONGEN_V2
+  #include <optmotiongen_core/Problem/IterativeQpProblem.h>
+  #include <optmotiongen_core/Task/BodyTask.h>
+#else
+  #include <optmotiongen/Problem/IterativeQpProblem.h>
+  #include <optmotiongen/Task/BodyTask.h>
+#endif
 
 #include <differentiable_rmap/RmapSampling.h>
 

--- a/launch/rmap_planning.launch
+++ b/launch/rmap_planning.launch
@@ -15,7 +15,7 @@
     </rosparam>
   </node>
 
-  <node pkg="optmotiongen" type="InteractiveMarkerManager.py" name="rviz_server"
+  <node pkg="optmotiongen_core" type="InteractiveMarkerManager.py" name="rviz_server"
         clear_params="true">
     <rosparam if="$(eval arg('sampling_space') == 'R2')">
       interactive_markers:

--- a/launch/rmap_planning_footstep.launch
+++ b/launch/rmap_planning_footstep.launch
@@ -12,7 +12,7 @@
     </rosparam>
   </node>
 
-  <node pkg="optmotiongen" type="InteractiveMarkerManager.py" name="rviz_server"
+  <node pkg="optmotiongen_core" type="InteractiveMarkerManager.py" name="rviz_server"
         clear_params="true">
     <rosparam>
       interactive_markers:

--- a/launch/rmap_planning_locomanip.launch
+++ b/launch/rmap_planning_locomanip.launch
@@ -15,7 +15,7 @@
     </rosparam>
   </node>
 
-  <node pkg="optmotiongen" type="InteractiveMarkerManager.py" name="rviz_server"
+  <node pkg="optmotiongen_core" type="InteractiveMarkerManager.py" name="rviz_server"
         clear_params="true">
     <rosparam>
       enable_initial_publish: true

--- a/launch/rmap_planning_multicontact.launch
+++ b/launch/rmap_planning_multicontact.launch
@@ -15,7 +15,7 @@
     </rosparam>
   </node>
 
-  <node pkg="optmotiongen" type="InteractiveMarkerManager.py" name="rviz_server"
+  <node pkg="optmotiongen_core" type="InteractiveMarkerManager.py" name="rviz_server"
         clear_params="true">
     <rosparam>
       enable_initial_publish: true

--- a/launch/rmap_planning_placement.launch
+++ b/launch/rmap_planning_placement.launch
@@ -23,7 +23,7 @@
     </rosparam>
   </node>
 
-  <node pkg="optmotiongen" type="InteractiveMarkerManager.py" name="rviz_server"
+  <node pkg="optmotiongen_core" type="InteractiveMarkerManager.py" name="rviz_server"
         clear_params="true">
     <rosparam>
       enable_initial_publish: true

--- a/launch/rmap_training.launch
+++ b/launch/rmap_training.launch
@@ -1,6 +1,7 @@
 <launch>
   <!-- R2, SE2, R3, or SE3 are supported -->
   <arg name="sampling_space" default="R2" />
+  <arg name="limb_option" default="" />
   <arg name="load_svm" default="false" />
 
   <node pkg="differentiable_rmap" type="NodeRmapTraining" name="rmap_training"
@@ -8,7 +9,7 @@
     <rosparam subst_value="true">
       sampling_space: $(arg sampling_space)
       config_path: $(find differentiable_rmap)/config/RmapTraining.yaml
-      bag_path: /tmp/rmap_sample_set_$(arg sampling_space).bag
+      bag_path: /tmp/rmap_sample_set_$(arg sampling_space)$(arg limb_option).bag
       svm_path: /tmp/rmap_svm_model_$(arg sampling_space).libsvm
       load_svm: $(arg load_svm)
       eval_bag_path: /tmp/rmap_sample_set_eval_$(arg sampling_space).bag

--- a/package.xml
+++ b/package.xml
@@ -24,7 +24,7 @@
   <depend>visualization_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>grid_map_ros</depend>
-  <depend>optmotiongen</depend>
+  <depend>optmotiongen_core</depend>
   <depend>libsvm-dev</depend>
 
   <build_depend>message_generation</build_depend>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,5 +24,8 @@ target_link_libraries(DiffRmap PUBLIC
   svm
   ${catkin_LIBRARIES}
   )
+
+target_compile_definitions(DiffRmap PUBLIC OPTMOTIONGEN_V2) # for optmotiongen-ver2
+
 # target_compile_options(DiffRmap PUBLIC -march=native)
 # target_link_options(DiffRmap PUBLIC -march=native)

--- a/src/RmapPlanning.cpp
+++ b/src/RmapPlanning.cpp
@@ -8,7 +8,11 @@
 #include <geometry_msgs/PoseStamped.h>
 #include <visualization_msgs/MarkerArray.h>
 
-#include <optmotiongen/Utils/RosUtils.h>
+#ifdef OPTMOTIONGEN_V2
+  #include <optmotiongen_core/Utils/RosUtils.h>
+#else
+  #include <optmotiongen/Utils/RosUtils.h>
+#endif
 
 #include <differentiable_rmap/GridUtils.h>
 #include <differentiable_rmap/RmapPlanning.h>

--- a/src/RmapPlanningFootstep.cpp
+++ b/src/RmapPlanningFootstep.cpp
@@ -10,8 +10,13 @@
 #include <jsk_recognition_msgs/PolygonArray.h>
 #include <visualization_msgs/MarkerArray.h>
 
-#include <optmotiongen/Func/CollisionFunc.h>
-#include <optmotiongen/Utils/RosUtils.h>
+#ifdef OPTMOTIONGEN_V2
+  #include <optmotiongen_core/Func/CollisionFunc.h>
+  #include <optmotiongen_core/Utils/RosUtils.h>
+#else
+  #include <optmotiongen/Func/CollisionFunc.h>
+  #include <optmotiongen/Utils/RosUtils.h>
+#endif
 
 #include <differentiable_rmap/GridUtils.h>
 #include <differentiable_rmap/RmapPlanningFootstep.h>

--- a/src/RmapPlanningLocomanip.cpp
+++ b/src/RmapPlanningLocomanip.cpp
@@ -9,7 +9,11 @@
 #include <sensor_msgs/PointCloud.h>
 #include <visualization_msgs/MarkerArray.h>
 
-#include <optmotiongen/Utils/RosUtils.h>
+#ifdef OPTMOTIONGEN_V2
+  #include <optmotiongen_core/Utils/RosUtils.h>
+#else
+  #include <optmotiongen/Utils/RosUtils.h>
+#endif
 
 #include <differentiable_rmap/GridUtils.h>
 #include <differentiable_rmap/RmapPlanningLocomanip.h>

--- a/src/RmapPlanningMulticontact.cpp
+++ b/src/RmapPlanningMulticontact.cpp
@@ -9,7 +9,11 @@
 #include <sensor_msgs/PointCloud.h>
 #include <visualization_msgs/MarkerArray.h>
 
-#include <optmotiongen/Utils/RosUtils.h>
+#ifdef OPTMOTIONGEN_V2
+  #include <optmotiongen_core/Utils/RosUtils.h>
+#else
+  #include <optmotiongen/Utils/RosUtils.h>
+#endif
 
 #include <differentiable_rmap/GridUtils.h>
 #include <differentiable_rmap/RmapPlanningMulticontact.h>

--- a/src/RmapPlanningPlacement.cpp
+++ b/src/RmapPlanningPlacement.cpp
@@ -10,7 +10,11 @@
 #include <optmotiongen_msgs/RobotStateArray.h>
 #include <visualization_msgs/MarkerArray.h>
 
-#include <optmotiongen/Utils/RosUtils.h>
+#ifdef OPTMOTIONGEN_V2
+  #include <optmotiongen_core/Utils/RosUtils.h>
+#else
+  #include <optmotiongen/Utils/RosUtils.h>
+#endif
 
 #include <differentiable_rmap/GridUtils.h>
 #include <differentiable_rmap/RmapPlanningPlacement.h>

--- a/src/RmapSampling.cpp
+++ b/src/RmapSampling.cpp
@@ -10,7 +10,11 @@
 
 #include <sch/S_Polyhedron/S_Polyhedron.h>
 
-#include <optmotiongen/Utils/RosUtils.h>
+#ifdef OPTMOTIONGEN_V2
+  #include <optmotiongen_core/Utils/RosUtils.h>
+#else
+  #include <optmotiongen/Utils/RosUtils.h>
+#endif
 
 #include <differentiable_rmap/RmapSampling.h>
 

--- a/src/RmapSamplingFootstep.cpp
+++ b/src/RmapSamplingFootstep.cpp
@@ -3,7 +3,11 @@
 #include <optmotiongen_msgs/RobotStateArray.h>
 #include <visualization_msgs/MarkerArray.h>
 
-#include <optmotiongen/Utils/RosUtils.h>
+#ifdef OPTMOTIONGEN_V2
+  #include <optmotiongen_core/Utils/RosUtils.h>
+#else
+  #include <optmotiongen/Utils/RosUtils.h>
+#endif
 
 #include <differentiable_rmap/RmapSamplingFootstep.h>
 

--- a/src/RmapSamplingIK.cpp
+++ b/src/RmapSamplingIK.cpp
@@ -2,7 +2,11 @@
 
 #include <optmotiongen_msgs/RobotStateArray.h>
 
-#include <optmotiongen/Utils/RosUtils.h>
+#ifdef OPTMOTIONGEN_V2
+  #include <optmotiongen_core/Utils/RosUtils.h>
+#else
+  #include <optmotiongen/Utils/RosUtils.h>
+#endif
 
 #include <differentiable_rmap/RmapSamplingIK.h>
 

--- a/src/RmapTraining.cpp
+++ b/src/RmapTraining.cpp
@@ -9,7 +9,11 @@
 #include <visualization_msgs/MarkerArray.h>
 #include <differentiable_rmap/RmapSampleSet.h>
 
-#include <optmotiongen/Utils/RosUtils.h>
+#ifdef OPTMOTIONGEN_V2
+  #include <optmotiongen_core/Utils/RosUtils.h>
+#else
+  #include <optmotiongen/Utils/RosUtils.h>
+#endif
 
 #include <differentiable_rmap/BaselineUtils.h>
 #include <differentiable_rmap/EvalUtils.h>

--- a/src/RmapVisualization.cpp
+++ b/src/RmapVisualization.cpp
@@ -7,7 +7,11 @@
 #include <visualization_msgs/MarkerArray.h>
 #include <differentiable_rmap/RmapSampleSet.h>
 
-#include <optmotiongen/Utils/RosUtils.h>
+#ifdef OPTMOTIONGEN_V2
+  #include <optmotiongen_core/Utils/RosUtils.h>
+#else
+  #include <optmotiongen/Utils/RosUtils.h>
+#endif
 
 #include <differentiable_rmap/RmapVisualization.h>
 #include <differentiable_rmap/SVMUtils.h>


### PR DESCRIPTION
Hello, this is Tsuru.

My system is based on optmotiongen-ver2-public, not the main branch.

As you know, the package names are slightly different (_optmotiongen_ vs _optmotiongen_core_),
therefore, I had to rename them.

I made a MACRO variable, __`OPTMOTIONGEN_V2`__, which can easily switch the version of header files.


However, some launch files and package.xml also have _"optmotiongen,"_
and it is not so easy to automatically rename them...

(It's better to make a new branch for optmotiongen-ver2, I wonder...)
(However, I don't know how much you are interested in this system.
If you want, I still can improve the switching system, but I don't know if it's worth implementing for you...
Then. please let me make this PR as a draft.)

